### PR TITLE
[GetTemplate] - Deep copy maps in constructor

### DIFF
--- a/src/tech/pxfd/GetTemplate.groovy
+++ b/src/tech/pxfd/GetTemplate.groovy
@@ -15,8 +15,8 @@ class GetTemplate {
   GetTemplate(def context, Map conatinersConf, Map podConf) {
     this.context = context
 
-    this.conatinersConf = conatinersConf
-    this.podConf = podConf
+    this.conatinersConf = Utils.mapDeepCopy(conatinersConf)
+    this.podConf = Utils.mapDeepCopy(podConf)
   }
 
   String render() {

--- a/src/tech/pxfd/Utils.groovy
+++ b/src/tech/pxfd/Utils.groovy
@@ -42,6 +42,7 @@ class Utils {
             this.context.error("ERROR " + msg)
     }
 
+    @NonCPS
     public static final Map mapDeepCopy(Map originalMap) {
         return new JsonSlurper().parseText(JsonOutput.toJson(originalMap))
     }


### PR DESCRIPTION
We need to do deep copies of the maps passed to GetTemplate constructor becase the original maps will be affecter by operations inside class methods due to "by reference" nature of the groovy.